### PR TITLE
Add excluded_trace configuration option to api-response.php

### DIFF
--- a/config/api-response.php
+++ b/config/api-response.php
@@ -114,4 +114,6 @@ return [
     */
 
     'trace' => (bool) env('APP_DEBUG', false),
+
+    'excluded_trace' => [],
 ];


### PR DESCRIPTION
This pull request introduces a small configuration change to the `config/api-response.php` file, adding a new option for excluded traces. This allows for specifying which traces should be omitted from API responses.