### PR TITLE
Dev development

### DIFF
--- a/src/Http/ApiResponseHandler.php
+++ b/src/Http/ApiResponseHandler.php
@@ -103,6 +103,22 @@ class ApiResponseHandler implements HandlesResponse
      */
     protected function getResourceName(Arrayable $arrayable): string
     {
+        // if ($arrayable->isEmpty()) {
+        //     $resource = basename($arrayable->path());
+        // } else {
+        //     $first = $arrayable->first();
+
+        //     if ($first instanceof Model) {
+        //         $resource = class_basename($first);
+        //     } else {
+        //         $resource = class_basename($arrayable);
+
+        //         $resource = str_replace(['Collection', 'Resource'], '', $resource);
+        //     }
+        // }
+
+        // return (string) Str::of($resource)->plural()->lower();
+
         if ($arrayable->isEmpty()) {
             $resource = basename($arrayable->path());
         } else {
@@ -112,11 +128,10 @@ class ApiResponseHandler implements HandlesResponse
                 $resource = class_basename($first);
             } else {
                 $resource = class_basename($arrayable);
-
                 $resource = str_replace(['Collection', 'Resource'], '', $resource);
             }
         }
 
-        return (string) Str::of($resource)->plural()->lower();
+        return (string) Str::of($resource)->plural()->snake();
     }
 }

--- a/src/Http/ApiResponseHandler.php
+++ b/src/Http/ApiResponseHandler.php
@@ -103,22 +103,6 @@ class ApiResponseHandler implements HandlesResponse
      */
     protected function getResourceName(Arrayable $arrayable): string
     {
-        // if ($arrayable->isEmpty()) {
-        //     $resource = basename($arrayable->path());
-        // } else {
-        //     $first = $arrayable->first();
-
-        //     if ($first instanceof Model) {
-        //         $resource = class_basename($first);
-        //     } else {
-        //         $resource = class_basename($arrayable);
-
-        //         $resource = str_replace(['Collection', 'Resource'], '', $resource);
-        //     }
-        // }
-
-        // return (string) Str::of($resource)->plural()->lower();
-
         if ($arrayable->isEmpty()) {
             $resource = basename($arrayable->path());
         } else {


### PR DESCRIPTION
This pull request makes a small adjustment to the way resource names are generated in API responses. The change ensures that resource names are now returned in snake_case plural form, rather than lowercase plural.

* Changed the return value in `getResourceName` in `ApiResponseHandler` to use `snake_case` instead of `lowercase` for plural resource names.