### PR TITLE
Add header handling to ApiResponseHandler for improved response manag…

### DIFF
--- a/src/Http/ApiResponseHandler.php
+++ b/src/Http/ApiResponseHandler.php
@@ -31,6 +31,10 @@ class ApiResponseHandler implements HandlesResponse
             default => $this->mergeData([$content])
         };
 
+        if (property_exists($response, 'headers')) {
+            $this->setHeaders($response->headers->all());
+        }
+
         if (method_exists($response, 'getStatusCode')) {
             $this->setStatusCode($response->getStatusCode());
         }


### PR DESCRIPTION
This pull request introduces an improvement to the `ApiResponseHandler` by ensuring that any headers present in the `Response` object are now set on the handler. This change makes the handler more robust and ensures that HTTP headers are correctly propagated.

- **HTTP Headers Handling:**
  * Updated the `__invoke` method in `ApiResponseHandler` to check for a `headers` property on the `Response` object and set those headers on the handler if present.