### PR TITLE
Fix header check in ApiResponseHandler to use isset instead of proper…

### DIFF
--- a/src/Http/ApiResponseHandler.php
+++ b/src/Http/ApiResponseHandler.php
@@ -31,7 +31,7 @@ class ApiResponseHandler implements HandlesResponse
             default => $this->mergeData([$content])
         };
 
-        if (property_exists($response, 'headers')) {
+        if (isset($response->headers)) {
             $this->setHeaders($response->headers->all());
         }
 


### PR DESCRIPTION
This pull request makes a minor update to the way headers are checked in the `ApiResponseHandler`. The change improves reliability by switching from `property_exists` to `isset` when verifying the presence of the `headers` property on the `$response` object.

* Updated the header check in the `__invoke` method of `ApiResponseHandler` to use `isset($response->headers)` instead of `property_exists`, ensuring compatibility with how headers are typically set and accessed.…